### PR TITLE
Update build script to output the right flavor

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,22 @@ this package as follows to allow automatic downloading:
 
 ## Upgrading
 
-To upgrade static libraries, run the following on the pcre source code.
+To upgrade static libraries, run the following script on Linux and Mac to create the necessary static libs.
 
-   ./configure --enable-jit --disable-shared
-   make
+   ./build_lib.sh
 
-The static library will be in `./lib/libpcre.a`
+The static library will be either `libpcre_darwin.a` or `libpcre_linux.a`
+
+The library is compiled with the following options:
+```
+--enable-jit
+--enable-utf
+--disable-shared
+--disable-cpp
+--enable-newline-is-any
+--with-match-limit=500000
+--with-match-limit-recursion=50000
+```
 
 ## History
 

--- a/build_lib.sh
+++ b/build_lib.sh
@@ -19,6 +19,12 @@ echo "Using temp directory $TEMP to build $SRC"
     make
   )
 )
-cp "$TEMP/$SRC/.libs/libpcre.a" ./
-echo "Copied static library to libpcre.a"
+PLATFORM="$(uname -s)"
+case "${PLATFORM}" in
+  Linux*)  OUTPUT=libpcre_linux.a;;
+  Darwin*) OUTPUT=libpcre_darwin.a;;
+  *)       OUTPUT=libpcre.a
+esac
+cp "$TEMP/$SRC/.libs/libpcre.a" "$OUTPUT"
+echo "Copied static library to $OUTPUT"
 rm -rf "$TEMP"


### PR DESCRIPTION
Update the build_lib script to detect the platform and copy the compiled library to the right destination.