### PR TITLE
Fix BUILD.bazel for external import

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,4 +1,3 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
@@ -6,8 +5,8 @@ go_library(
         "pcre.go",
         "pcre.h",
         "pcre_fallback.h",
-        "platform_darwin_arm64.go",
         "platform_darwin_amd64.go",
+        "platform_darwin_arm64.go",
         "platform_linux.go",
     ],
     cdeps = [":libpc"],
@@ -20,9 +19,9 @@ cc_import(
     name = "libpc",
     hdrs = ["pcre.h"],
     static_library = select({
-        "@io_bazel_rules_go//go/platform:darwin_amd64": "libpcre_darwin_x86_64.a",
-        "@io_bazel_rules_go//go/platform:darwin_arm64": "libpcre_darwin_arm64.a",
-        "@io_bazel_rules_go//go/platform:linux": "libpcre_linux.a",
+        "@io_bazel_rules_go//go/platform:darwin_amd64": ":libpcre_darwin_x86_64.a",
+        "@io_bazel_rules_go//go/platform:darwin_arm64": ":libpcre_darwin_arm64.a",
+        "@io_bazel_rules_go//go/platform:linux": ":libpcre_linux.a",
     }),
     alwayslink = 1,
 )

--- a/platform_darwin_amd64.go
+++ b/platform_darwin_amd64.go
@@ -1,4 +1,3 @@
 package pcre
 
-// #cgo LDFLAGS: ${SRCDIR}/libpcre_darwin_x86_64.a
 import "C"

--- a/platform_darwin_arm64.go
+++ b/platform_darwin_arm64.go
@@ -1,4 +1,3 @@
 package pcre
 
-// #cgo LDFLAGS: ${SRCDIR}/libpcre_darwin_arm64.a
 import "C"

--- a/platform_linux.go
+++ b/platform_linux.go
@@ -1,4 +1,3 @@
 package pcre
 
-// #cgo LDFLAGS: ${SRCDIR}/libpcre_linux.a
 import "C"


### PR DESCRIPTION
With cgo LDFLAGS, it creates clinkopts in BUILD.bazel.
However, that uses relative paths and it breaks build if
the workspace is imported from external workspace.
For example it fails to build with @spark from CDM workspace
in our repo. As we specify library in the cc_import, for
bazel build we don't need the comments.