### PR TITLE
Fix UTs running directly from go

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "platform_darwin_arm64.go",
         "platform_linux.go",
     ],
+    clinkopts = [],  # keep
     cdeps = [":libpc"],
     cgo = True,
     importpath = "github.com/rubrikinc/go-pcre",

--- a/platform_darwin_amd64.go
+++ b/platform_darwin_amd64.go
@@ -1,3 +1,4 @@
 package pcre
 
+// #cgo LDFLAGS: ${SRCDIR}/libpcre_darwin_x86_64.a
 import "C"

--- a/platform_darwin_arm64.go
+++ b/platform_darwin_arm64.go
@@ -1,3 +1,4 @@
 package pcre
 
+// #cgo LDFLAGS: ${SRCDIR}/libpcre_darwin_arm64.a
 import "C"

--- a/platform_linux.go
+++ b/platform_linux.go
@@ -1,3 +1,4 @@
 package pcre
 
+// #cgo LDFLAGS: ${SRCDIR}/libpcre_linux.a
 import "C"


### PR DESCRIPTION
#10 fixed builds with bazel, but running tests
or binaries directly with go fails after then.
This PR fixes it by reverting changes for cgo,
but adding empty clinkopts with #keep.